### PR TITLE
Now

### DIFF
--- a/now.json
+++ b/now.json
@@ -13,5 +13,8 @@
       { "src": "/precache-manifest.(.*)", "dest": "/precache-manifest.$1" },
       { "src": "/service-worker.js", "headers": { "cache-control": "s-maxage=0" }, "dest": "/service-worker.js" },
       { "src": "/(.*)", "headers": {"cache-control": "s-maxage=0"}, "dest": "/index.html" }
-    ]
+    ],
+    "github": {
+      "silent": true
+    }
 }

--- a/now.json
+++ b/now.json
@@ -1,0 +1,17 @@
+{
+    "version": 2,
+    "name": "squid",
+    "alias": "squid.pink",
+    "builds": [
+        { "src": "package.json", "use": "@now/static-build", "config": { "distDir": "build" } }
+    ],
+    "routes": [
+      { "src": "/static/(.*)", "headers": { "cache-control": "s-maxage=31536000,immutable" }, "dest": "/static/$1" },
+      { "src": "/favicon.ico", "dest": "/favicon.ico" },
+      { "src": "/asset-manifest.json", "dest": "/asset-manifest.json" },
+      { "src": "/manifest.json", "dest": "/manifest.json" },
+      { "src": "/precache-manifest.(.*)", "dest": "/precache-manifest.$1" },
+      { "src": "/service-worker.js", "headers": { "cache-control": "s-maxage=0" }, "dest": "/service-worker.js" },
+      { "src": "/(.*)", "headers": {"cache-control": "s-maxage=0"}, "dest": "/index.html" }
+    ]
+}

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "start": "react-scripts start",
     "build": "react-scripts build",
     "test": "react-scripts test --env=jsdom",
-    "eject": "react-scripts eject"
+    "eject": "react-scripts eject",    
+    "now-build": "react-scripts build"
   },
   "eslintConfig": {
     "extends": "react-app"


### PR DESCRIPTION
adds continuous deployment using zeit/now.

this seems to deal well with dev/live deployments:

- master deploys to https://squid.pink
- any push to any branch deploys to https://squid.squid.now.sh and a unique url (e.g. https://squid-o73e781j1.now.sh)

one outstanding issue is the auth0 needs to cope with the changing redirect uris